### PR TITLE
Use grunt.template format in variables keys and prefix value

### DIFF
--- a/tasks/replace.js
+++ b/tasks/replace.js
@@ -28,7 +28,7 @@ module.exports = function (grunt) {
       prefix = config.prefix,
       locals = {},
       processed = 0;
-
+      
     if (typeof variables === 'object') {
       grunt.verbose.writeln('Using "' + target + '" replace variables options.');
     } else {
@@ -44,13 +44,15 @@ module.exports = function (grunt) {
       grunt.verbose.writeln('Using master replacer prefix options.');
       prefix = grunt.config('replacer.prefix') || '@@';
     }
-
+    
+    prefix = grunt.template.process(prefix);
+    
     grunt.verbose.writeflags(prefix, 'prefix');
 
     Object.keys(variables).forEach(function (variable) {
       var value = variables[variable];
       if (typeof value === 'string') {
-        locals[variable] = grunt.template.process(value);
+        locals[grunt.template.process(variable)] = grunt.template.process(value);
       }
     });
 


### PR DESCRIPTION
I am using plugin in a project, and was necessary this functionality. I think it is an interesting feature to plugin.
