### PR TITLE
Added `verbose` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ Default: `false`
 
 Whether to copy or set the existing file permissions. Set to `true` to copy the existing file permissions. Or set to the mode, i.e.: `0644`, that copied files will be set to.
 
+#### verbose
+Type: `Boolean`
+Default: `true`
+
+If set to `false`, the output for each replaced file will be suppressed.
+
 ### Built-in Replacements
 
 Few matching rules are provided by default and can be used anytime (these will be affected by the `options` given):

--- a/tasks/replace.js
+++ b/tasks/replace.js
@@ -28,7 +28,8 @@ module.exports = function (grunt) {
       processContentExclude: [],
       patterns: [],
       excludeBuiltins: false,
-      force: true
+      force: true,
+      verbose: true
     });
 
     // attach builtins
@@ -125,7 +126,7 @@ module.exports = function (grunt) {
         if (result === false && options.force === true) {
           result = contents;
         }
-        if (result !== false) {
+        if (result !== false && options.verbose === true) {
           grunt.log.writeln('Replace ' + chalk.cyan(source) + ' → ' +
             chalk.green(target));
         }


### PR DESCRIPTION
If set to `false`, the output for each replaced file will be suppressed.
