### PR TITLE
Upgrade lodash version to 4.17.21 regarding CWE-78

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "applause": "^2.0.0",
     "chalk": "^4.1.0",
     "file-sync-cmp": "^0.1.0",
-    "lodash": "^4.11.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "ava": "^3.15.0",


### PR DESCRIPTION
We have a Vulnerability related to CWE-78 and Lodash 4.17.21 fixed it with below commit info.

* https://cwe.mitre.org/data/definitions/78.html
* lodash/lodash@3469357